### PR TITLE
Web Storage backend for references

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -24,6 +24,10 @@ Flag sqlite
   Description: Build the sqlite module.
   Default: false
 
+Flag webstorage
+  Description: Build the Web Storage module.
+  Default: false
+
 
 Library ocsipersist
   Path: src
@@ -46,6 +50,14 @@ Library "ocsipersist-sqlite"
   Modules: Ocsipersist
   BuildDepends: threads, ocsigenserver.baselib, ocsipersist, sqlite3
 
+Library "ocsipersist-webstorage"
+  FindlibName: webstorage
+  FindlibParent: ocsipersist
+  Build$: flag(webstorage)
+  CompiledObject: byte
+  Path: src_webstorage
+  Modules: Ocsipersist_webstorage
+  BuildDepends: js_of_ocaml, js_of_ocaml.syntax, ocsipersist
 
 
 Document "ocsipersist"

--- a/opam
+++ b/opam
@@ -12,6 +12,7 @@ build: [
   ["ocaml" "setup.ml" "-configure"
       "--%{dbm:enable}%-dbm"
       "--%{sqlite3:enable}%-sqlite"
+      "--%{js_of_ocaml:enable}%-webstorage"
       "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]
 ]
@@ -28,4 +29,5 @@ depends: [
 depopts: [
   "dbm"
   "sqlite3"
+  "js_of_ocaml"
 ]

--- a/src_dbm/ocsipersist.mli
+++ b/src_dbm/ocsipersist.mli
@@ -1,1 +1,2 @@
-include Ocsipersist_sig.T
+include Ocsipersist_sig.REF with type 'a wrap := 'a Lwt.t
+include Ocsipersist_sig.TABLE

--- a/src_sqlite/ocsipersist.mli
+++ b/src_sqlite/ocsipersist.mli
@@ -1,1 +1,2 @@
-include Ocsipersist_sig.T
+include Ocsipersist_sig.REF with type 'a wrap := 'a Lwt.t
+include Ocsipersist_sig.TABLE

--- a/src_webstorage/ocsipersist_webstorage.ml
+++ b/src_webstorage/ocsipersist_webstorage.ml
@@ -1,0 +1,61 @@
+(* Ocsigen
+ * http://www.ocsigen.org
+ * Module ocsipersist.mli
+ * Copyright (C) 2016 Vasilis Papavasileiou
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, with linking exception;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *)
+
+type 'a wrap = 'a
+
+let storage () =
+  Js.Optdef.case (Dom_html.window##localStorage)
+    (fun () -> failwith "Browser storage not supported")
+    (fun v -> v)
+
+type 'a t = Js.js_string Js.t
+
+let make_id ~store ~name : 'a t =
+  Js.string (Printf.sprintf "__ocsipersist_%s_%s" store name)
+
+type store = string
+
+let open_store s = s
+
+let set id v =
+  (storage ())##setItem(id, Json.output v)
+
+let make_persistent_lazy ~store ~name ~default =
+  let id = make_id ~store ~name in
+  let x = (storage ())##getItem(id)
+  and f _ = id
+  and g () = set id (default ()); id in
+  Js.Opt.case x g f
+
+let make_persistent_lazy_lwt = make_persistent_lazy
+
+let make_persistent ~store ~name ~default =
+  let default () = default in
+  make_persistent_lazy ~store ~name ~default
+
+let get id =
+  let x = (storage ())##getItem(id)
+  and f = Json.unsafe_input
+  and g () =
+    (* this is not supposed to fail, beause the reference must have
+       been initialized via make_persistent* *)
+    failwith "get"
+  in
+  Js.Opt.case x g f

--- a/src_webstorage/ocsipersist_webstorage.mli
+++ b/src_webstorage/ocsipersist_webstorage.mli
@@ -1,0 +1,1 @@
+include Ocsipersist_sig.REF with type 'a wrap = 'a


### PR DESCRIPTION
This PR provides a backend based on  [Web Storage](https://www.w3.org/TR/webstorage/) (`localStorage`) for use with JSOO.

Currently, only references are implemented. Web Storage is not for tabular data; that's the business of [IndexedDB](https://www.w3.org/TR/IndexedDB/). I hope to provide an IndexedDB-based implementation of tables soon.

I have slightly generalized the `REF` signature with a `wrap` constructor. For the standard backends, `wrap` amounts to `Lwt.t`. Web Storage is synchronous, so it would be misleading to implement a faux-`Lwt` signature by throwing in some `Lwt.return`'s. The new module is named `Ocsipersist_webstorage`, because its signature differs from the old ones.
